### PR TITLE
Fix incorrect use of coercion

### DIFF
--- a/lib/Crane/List.pm6
+++ b/lib/Crane/List.pm6
@@ -83,7 +83,7 @@ multi sub list(
     --> List:D
 )
 {
-    List({:path(@carry), :value($container)});
+    ({:path(@carry), :value($container)},);
 }
 
 # end method list }}}

--- a/t/methods/list.t
+++ b/t/methods/list.t
@@ -12,7 +12,7 @@ subtest({
     my $x = 1;
     is-deeply(
         Crane.list($x),
-        List({:path(()), :value(1)}),
+        ({:path(()), :value(1)},),
         'Is expected value'
     );
 
@@ -120,7 +120,7 @@ subtest({
     my %from-toml = :hello({});
     is-deeply(
         Crane.list(%from-toml),
-        List({:path["hello"], :value({})}),
+        ({:path["hello"], :value({})},),
         'Is expected value'
     );
 
@@ -128,14 +128,14 @@ subtest({
     %from-toml = :hello([{}]);
     is-deeply(
         Crane.list(%from-toml),
-        List({:path["hello"], :value([{}])}),
+        ({:path["hello"], :value([{}])},),
         'Is expected value'
     );
 
     %from-toml = :hello([]);
     is-deeply(
         Crane.list(%from-toml),
-        List({:path["hello"], :value([])}),
+        ({:path["hello"], :value([])},),
         'Is expected value'
     );
 });


### PR DESCRIPTION
Previously incorrect behavior of coercions caused `List(%h)` to result in a list consisting of a single hash element. But the above construct is actually equivalent to `%h.List`. There're two approaches resulting in the desired out come:

- `List.new(%h)`
- (%h,)

For this fix I've chosen the latter as more elegant.